### PR TITLE
Gosh/extraction logic

### DIFF
--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/HexTile_Temp.prefab
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/HexTile_Temp.prefab
@@ -870,6 +870,9 @@ MonoBehaviour:
   defaultColor: {r: 0.43137255, g: 0.8392157, b: 0.8352941, a: 1}
   flaggedColor: {r: 0, g: 1, b: 1, a: 1}
   trapColor: {r: 1, g: 0, b: 0, a: 1}
+  mineralPrefab: {fileID: 6151989773130266523, guid: 942e9ead58827f1458cae0d0dcdfb280, type: 3}
+  disarmedTrapPrefab: {fileID: 3202705609614651514, guid: 1c646704cf56f1a439120c97e1d77294, type: 3}
+  mineralCollectiblePrefab: {fileID: 7194570165873570679, guid: 785f0afa1a4f1d648bde78dd9c09372e, type: 3}
   axialCoords: {x: 0, y: 0}
   isTrap: 0
   isRevealed: 0

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Mineral.prefab
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Mineral.prefab
@@ -1,0 +1,110 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6151989773130266523
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6759544162113878268}
+  - component: {fileID: 5042650868709249076}
+  - component: {fileID: 6021511372603276582}
+  - component: {fileID: 4312745463092588313}
+  m_Layer: 0
+  m_Name: Mineral
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6759544162113878268
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6151989773130266523}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5042650868709249076
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6151989773130266523}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6021511372603276582
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6151989773130266523}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: fb5d64e1e45781a42b74834688e9a0b0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &4312745463092588313
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6151989773130266523}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Mineral.prefab.meta
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Mineral.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 942e9ead58827f1458cae0d0dcdfb280
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/MineralDrop.prefab
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/MineralDrop.prefab
@@ -1,0 +1,110 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7194570165873570679
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3310040447333876758}
+  - component: {fileID: 9044163991004747831}
+  - component: {fileID: 470947866188378661}
+  - component: {fileID: 2891164080440322429}
+  m_Layer: 0
+  m_Name: MineralDrop
+  m_TagString: MineralCollectible
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3310040447333876758
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7194570165873570679}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.8, y: 0.8, z: 0.8}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &9044163991004747831
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7194570165873570679}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &470947866188378661
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7194570165873570679}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: fb5d64e1e45781a42b74834688e9a0b0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &2891164080440322429
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7194570165873570679}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/MineralDrop.prefab.meta
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/MineralDrop.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 785f0afa1a4f1d648bde78dd9c09372e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Trap.mat
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Trap.mat
@@ -1,0 +1,137 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-7584518060530836389
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 9
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Trap
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _XRMotionVectorsPass: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.9528302, g: 0.4590287, b: 0, a: 1}
+    - _Color: {r: 0.95283014, g: 0.4590286, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Trap.mat.meta
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Trap.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 101ce7d54b2d1a4429a5cb5b14eef5ed
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Trap.prefab
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Trap.prefab
@@ -1,0 +1,110 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3202705609614651514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1658418930008397819}
+  - component: {fileID: 6196158439041478432}
+  - component: {fileID: 254760462938966031}
+  - component: {fileID: 3233875108444590293}
+  m_Layer: 0
+  m_Name: Trap
+  m_TagString: DisarmedExplosive
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1658418930008397819
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3202705609614651514}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6196158439041478432
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3202705609614651514}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &254760462938966031
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3202705609614651514}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 101ce7d54b2d1a4429a5cb5b14eef5ed, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &3233875108444590293
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3202705609614651514}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Trap.prefab.meta
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Trap.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1c646704cf56f1a439120c97e1d77294
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/TrapProjectile.prefab
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/TrapProjectile.prefab
@@ -1,0 +1,123 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &456487052918316408
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6404969760239256767}
+  - component: {fileID: 8392416127301578987}
+  - component: {fileID: 8863729449248862939}
+  - component: {fileID: 2110171676517529631}
+  - component: {fileID: 4671976983597380603}
+  m_Layer: 0
+  m_Name: TrapProjectile
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6404969760239256767
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456487052918316408}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8392416127301578987
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456487052918316408}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8863729449248862939
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456487052918316408}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 101ce7d54b2d1a4429a5cb5b14eef5ed, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &2110171676517529631
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456487052918316408}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &4671976983597380603
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456487052918316408}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3ec5d59f932583c40a6d1943d938ff04, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/TrapProjectile.prefab.meta
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/TrapProjectile.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 348029de7e6ee7744a4b4da424b78ed1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Yellow.mat
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Yellow.mat
@@ -1,0 +1,137 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-8708874973732950288
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 9
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Yellow
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _XRMotionVectorsPass: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.9962779, g: 1, b: 0, a: 1}
+    - _Color: {r: 0.99627787, g: 1, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Yellow.mat.meta
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Prefabs/Gameplay/Yellow.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb5d64e1e45781a42b74834688e9a0b0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Scenes/Levels/Test_Level_01.unity
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Scenes/Levels/Test_Level_01.unity
@@ -491,6 +491,10 @@ PrefabInstance:
       propertyPath: carriedExplosiveVisual
       value: 
       objectReference: {fileID: 592056396}
+    - target: {fileID: 4736629785226461007, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
+      propertyPath: explosiveProjectilePrefab
+      value: 
+      objectReference: {fileID: 456487052918316408, guid: 348029de7e6ee7744a4b4da424b78ed1, type: 3}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects:

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Scenes/Levels/Test_Level_01.unity
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Scenes/Levels/Test_Level_01.unity
@@ -201,7 +201,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       propertyPath: m_ActionEvents.Array.size
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       propertyPath: m_ActionEvents.Array.data[0].m_ActionId
@@ -228,6 +228,10 @@ PrefabInstance:
       value: 10b5ba1d-df1b-40c7-952e-3de3da7dbc60
       objectReference: {fileID: 0}
     - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
+      propertyPath: m_ActionEvents.Array.data[6].m_ActionId
+      value: 8a6b3349-5bf7-4446-80bd-a6e59257c0b6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       propertyPath: m_ActionEvents.Array.data[0].m_ActionName
       value: 'Player/ToggleProspecting[/Keyboard/tab]'
       objectReference: {fileID: 0}
@@ -252,6 +256,10 @@ PrefabInstance:
       value: 'Player/UseItem[/Keyboard/e]'
       objectReference: {fileID: 0}
     - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
+      propertyPath: m_ActionEvents.Array.data[6].m_ActionName
+      value: 'Player/ThrowMode[/Keyboard/f]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       propertyPath: m_ActionEvents.Array.data[0].m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
@@ -273,6 +281,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       propertyPath: m_ActionEvents.Array.data[5].m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
+      propertyPath: m_ActionEvents.Array.data[6].m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
@@ -304,6 +316,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
+      propertyPath: m_ActionEvents.Array.data[6].m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       propertyPath: m_ActionEvents.Array.data[0].m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 180154213}
@@ -331,6 +347,10 @@ PrefabInstance:
       propertyPath: m_ActionEvents.Array.data[5].m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 2019792518}
+    - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
+      propertyPath: m_ActionEvents.Array.data[6].m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 180154213}
     - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       propertyPath: m_ActionEvents.Array.data[0].m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
@@ -360,6 +380,10 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
+      propertyPath: m_ActionEvents.Array.data[6].m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       propertyPath: m_ActionEvents.Array.data[0].m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: OnToggleProspecting
       objectReference: {fileID: 0}
@@ -382,6 +406,10 @@ PrefabInstance:
     - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       propertyPath: m_ActionEvents.Array.data[5].m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: OnUseItem
+      objectReference: {fileID: 0}
+    - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
+      propertyPath: m_ActionEvents.Array.data[6].m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnThrowMode
       objectReference: {fileID: 0}
     - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       propertyPath: m_ActionEvents.Array.data[0].m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
@@ -412,6 +440,10 @@ PrefabInstance:
       value: TileInventoryController, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
+      propertyPath: m_ActionEvents.Array.data[6].m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: PlayerController, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       propertyPath: m_ActionEvents.Array.data[0].m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
@@ -435,6 +467,10 @@ PrefabInstance:
       propertyPath: m_ActionEvents.Array.data[5].m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
+    - target: {fileID: 4313579626097955744, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
+      propertyPath: m_ActionEvents.Array.data[6].m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 4736629785226461007, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       propertyPath: holoCone
       value: 
@@ -451,9 +487,16 @@ PrefabInstance:
       propertyPath: tileSelectionCamera
       value: 
       objectReference: {fileID: 1619433642}
+    - target: {fileID: 4736629785226461007, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
+      propertyPath: carriedExplosiveVisual
+      value: 
+      objectReference: {fileID: 592056396}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 985109150596212889, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 592056400}
     - targetCorrespondingSourceObject: {fileID: 985109150596212889, guid: 05b926eeed9a6ff4b8e01c22badca291, type: 3}
       insertIndex: -1
       addedObject: {fileID: 807910723}
@@ -941,6 +984,114 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 544305443}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &592056396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 592056400}
+  - component: {fileID: 592056399}
+  - component: {fileID: 592056398}
+  - component: {fileID: 592056397}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!135 &592056397
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 592056396}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &592056398
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 592056396}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 101ce7d54b2d1a4429a5cb5b14eef5ed, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &592056399
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 592056396}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &592056400
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 592056396}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.44000006, z: 0.64}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 180154217}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &657443900 stripped
 MonoBehaviour:
@@ -2315,6 +2466,14 @@ MonoBehaviour:
   gridRadius: 16
   trapDensity: 0.15
   safeZoneRadius: 1
+  baseMineralQuota: 8
+  clusterSizeRatios:
+  - size: 1
+    ratio: 0.6
+  - size: 2
+    ratio: 0.3
+  - size: 3
+    ratio: 0.1
   heatMapController: {fileID: 920069169}
 --- !u!4 &920069168
 Transform:

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Core/GameManager.cs
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Core/GameManager.cs
@@ -9,7 +9,9 @@ public enum GameState
 {
     Exploration,    // El jugador se mueve libremente por el mundo en 3D.
     Prospecting,    // El jugador observa la cuadrícula holográfica desde una vista orbital.
-    TileSelection   // El jugador navega y selecciona tiles individuales en la cuadrícula.
+    TileSelection,  // El jugador navega y selecciona tiles individuales en la cuadrícula.
+    CarryingExplosive, // El jugador transporta un explosivo con movimiento limitado.
+    ThrowObject     // El jugador está apuntando para lanzar un explosivo.
 }
 
 /// <summary>
@@ -89,10 +91,26 @@ public class GameManager : MonoBehaviour
 
     public void EnterExplorationMode()
     {
-        // Se puede volver a Exploration desde Prospecting o TileSelection.
-        if (CurrentState == GameState.Prospecting || CurrentState == GameState.TileSelection)
+        // Se puede volver a Exploration desde varios estados.
+        if (CurrentState == GameState.Prospecting || CurrentState == GameState.TileSelection || CurrentState == GameState.CarryingExplosive || CurrentState == GameState.ThrowObject)
         {
             SwitchState(GameState.Exploration);
+        }
+    }
+
+    public void EnterThrowObjectMode()
+    {
+        if (CurrentState == GameState.CarryingExplosive)
+        {
+            SwitchState(GameState.ThrowObject);
+        }
+    }
+
+    public void EnterCarryingExplosiveMode()
+    {
+        if (CurrentState == GameState.Exploration)
+        {
+            SwitchState(GameState.CarryingExplosive);
         }
     }
     

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Gameplay/ExplosiveProjectile.cs
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Gameplay/ExplosiveProjectile.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+using System.Collections;
+
+public class ExplosiveProjectile : MonoBehaviour
+{
+    /// <summary>
+    /// Coroutine to move the object along a parabolic arc to the target destination.
+    /// </summary>
+    /// <param name="targetPosition">The world position to travel to.</param>
+    /// <param name="duration">The total time the travel should take.</param>
+    /// <param name="arcHeight">The maximum height of the arc.</param>
+    /// <returns>IEnumerator for the coroutine.</returns>
+    public IEnumerator TravelToTarget(Vector3 targetPosition, float duration, float arcHeight)
+    {
+        Vector3 startPosition = transform.position;
+        float timer = 0.0f;
+
+        while (timer < duration)
+        {
+            // Calculate the current position along the arc
+            float t = timer / duration;
+            // This formula creates a parabolic curve for the y-axis
+            float yOffset = arcHeight * 4 * (t - t * t);
+            transform.position = Vector3.Lerp(startPosition, targetPosition, t) + new Vector3(0, yOffset, 0);
+
+            timer += Time.deltaTime;
+            yield return null;
+        }
+
+        // Ensure the projectile ends exactly at the target position
+        transform.position = targetPosition;
+    }
+}

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Gameplay/ExplosiveProjectile.cs.meta
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Gameplay/ExplosiveProjectile.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3ec5d59f932583c40a6d1943d938ff04

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Inventory/TileInventoryController.cs
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Inventory/TileInventoryController.cs
@@ -73,21 +73,24 @@ public class TileInventoryController : MonoBehaviour
     // --- LÓGICA DE ESTADO MEJORADA ---
     private void HandleGameStateChanged(GameState newState)
     {
-        if (newState == GameState.TileSelection)
+        // The inventory should only be visible during tile selection.
+        bool shouldBeVisible = (newState == GameState.TileSelection);
+
+        inventoryUIParent.SetActive(shouldBeVisible);
+
+        if (shouldBeVisible)
         {
-            // Al entrar en el estado, mostramos el inventario inmediatamente
-            // en la posición del tile que ya está seleccionado.
+            // When entering the state, show the inventory immediately
+            // at the position of the already selected tile.
             UpdatePosition(prospectingManager.CurrentlySelectedTile);
 
-            // Y nos suscribimos al input de navegación del inventario.
+            // And subscribe to the inventory navigation input.
             if (navigateAction != null) navigateAction.performed += OnNavigate;
             if (useItemAction != null) useItemAction.performed += OnUseItem;
         }
         else
         {
-            // Al salir de este estado, nos aseguramos de ocultar la UI
-            // y de dejar de escuchar el input.
-            inventoryUIParent.SetActive(false);
+            // When leaving the state, ensure we unsubscribe from the input.
             if (navigateAction != null) navigateAction.performed -= OnNavigate;
             if (useItemAction != null) useItemAction.performed -= OnUseItem;
         }
@@ -96,6 +99,13 @@ public class TileInventoryController : MonoBehaviour
     // --- LÓGICA DE POSICIÓN REFINADA ---
     private void UpdatePosition(HexTile targetTile)
     {
+        // Only update the position and show the UI if we are in the correct state.
+        if (GameManager.Instance.CurrentState != GameState.TileSelection)
+        {
+            inventoryUIParent.SetActive(false); // Ensure it's off
+            return;
+        }
+
         // Si no hay un tile objetivo, no hay nada que hacer.
         if (targetTile == null)
         {

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Inventory/TileInventoryController.cs
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Inventory/TileInventoryController.cs
@@ -249,6 +249,9 @@ public class TileInventoryController : MonoBehaviour
     
     public void OnUseItem(InputAction.CallbackContext context)
     {
+        // Only allow item use in the TileSelection state to prevent input conflicts.
+        if (GameManager.Instance.CurrentState != GameState.TileSelection) return;
+
         if (!context.performed) return;
 
         HexTile targetTile = prospectingManager.CurrentlySelectedTile;

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Player/PlayerController.cs
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Player/PlayerController.cs
@@ -94,7 +94,9 @@ public class PlayerController : MonoBehaviour
     /// </summary>
     public void OnMove(InputAction.CallbackContext context)
     {
-        if (GameManager.Instance.CurrentState == GameState.TileSelection && context.performed)
+        // Allow tile navigation in both standard selection and throw-aiming modes.
+        if ((GameManager.Instance.CurrentState == GameState.TileSelection || GameManager.Instance.CurrentState == GameState.ThrowObject) 
+            && context.performed)
         {
             Vector2 moveInput = context.ReadValue<Vector2>();
             NavigateTiles(moveInput);
@@ -254,7 +256,8 @@ public class PlayerController : MonoBehaviour
     {
         if (!context.performed || GameManager.Instance.CurrentState != GameState.CarryingExplosive) return;
 
-        GameManager.Instance.EnterThrowObjectMode();
+        // --- REORDERED LOGIC ---
+        // First, find and select the closest tile to start aiming from.
         FindClosestTile();
         if (currentTargetTile != null)
         {
@@ -262,9 +265,12 @@ public class PlayerController : MonoBehaviour
         }
         else
         {
-            // If no tile is nearby, select the first tile of the grid as a fallback
+            // If no tile is nearby, select the first tile of the grid as a fallback.
             ProspectingManager.Instance.SelectFirstTile();
         }
+
+        // Then, switch the game state. This ensures the camera focuses on the correct tile.
+        GameManager.Instance.EnterThrowObjectMode();
     }
 
     private void ThrowExplosive(HexTile targetTile)

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Player/PlayerController.cs
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Player/PlayerController.cs
@@ -11,6 +11,7 @@ public class PlayerController : MonoBehaviour
 
     [Header("Interaction Settings")]
     [SerializeField] private float interactionRadius = 2f;
+    [SerializeField] private float throwRange = 10f; // Rango para lanzar el explosivo
     [SerializeField] private LayerMask tileLayer;
 
     [Header("Movement Settings")]
@@ -18,6 +19,7 @@ public class PlayerController : MonoBehaviour
 
     [Header("Visuals")]
     [SerializeField] private GameObject holoCone;
+    [SerializeField] private GameObject carriedExplosiveVisual; // Visual del explosivo que carga el jugador
 
     // --- Referencias de Componentes ---
     private PlayerMovement playerMovement;
@@ -51,7 +53,7 @@ public class PlayerController : MonoBehaviour
         moveInputVector = playerInput.actions["Move"].ReadValue<Vector2>();
 
         // --- Lógica de Movimiento Continuo ---
-        if (currentState == GameState.Exploration)
+        if (currentState == GameState.Exploration || currentState == GameState.CarryingExplosive)
         {
             playerMovement.ProcessMove(moveInputVector);
         }
@@ -103,6 +105,12 @@ public class PlayerController : MonoBehaviour
     {
         if (!context.performed) return;
 
+        if (GameManager.Instance.CurrentState == GameState.CarryingExplosive)
+        {
+            DetonateCarriedExplosive();
+            return;
+        }
+
         // Obtenemos la instancia del GameManager una sola vez.
         var gameManager = GameManager.Instance;
 
@@ -124,6 +132,7 @@ public class PlayerController : MonoBehaviour
     public void OnConfirmSelection(InputAction.CallbackContext context)
     {
         if (!context.performed) return;
+
         GameState currentState = GameManager.Instance.CurrentState;
 
         if (currentState == GameState.Prospecting && currentTargetTile != null)
@@ -139,44 +148,78 @@ public class PlayerController : MonoBehaviour
         }
         else if (currentState == GameState.TileSelection)
         {
-            GameManager.Instance.SwitchState(GameState.Prospecting);
+            HexTile selectedTile = ProspectingManager.Instance.CurrentlySelectedTile;
+            if (selectedTile != null)
+            {
+                ProspectingManager.Instance.RevealTile(selectedTile);
+            }
         }
     }
 
     public void OnDisarm(InputAction.CallbackContext context)
     {
-        if (context.performed && GameManager.Instance.CurrentState == GameState.TileSelection)
+        if (!context.performed) return;
+
+        GameState currentState = GameManager.Instance.CurrentState;
+
+        if (currentState == GameState.TileSelection)
         {
             HexTile tileToDisarm = ProspectingManager.Instance.CurrentlySelectedTile;
-            if (tileToDisarm != null)
+            if (tileToDisarm != null && tileToDisarm.isTrap)
+            {
+                tileToDisarm.DefuseTrap();
+                GameManager.Instance.SwitchState(GameState.Prospecting);
+            }
+            else if (tileToDisarm != null)
             {
                 ProspectingManager.Instance.RevealTile(tileToDisarm);
             }
         }
+        else if (currentState == GameState.ThrowObject)
+        {
+            HexTile targetTile = ProspectingManager.Instance.CurrentlySelectedTile;
+            if (targetTile != null)
+            {
+                ThrowExplosive(targetTile);
+            }
+        }
     }
-    
+
     // --- LÓGICA PRIVADA Y DE GESTIÓN DE ESTADO ---
 
     private void HandleGameStateChange(GameState newState)
     {
-        playerMovement.enabled = (newState == GameState.Exploration);
-        if (playerCamera != null)
-            playerCamera.enabled = (newState == GameState.Exploration || newState == GameState.Prospecting);
-        if (tileSelectionCamera != null)
-            tileSelectionCamera.enabled = (newState == GameState.TileSelection);
+        playerMovement.enabled = (newState == GameState.Exploration || newState == GameState.CarryingExplosive);
 
-        // --- Lógica del HoloCone ---
+        if (playerCamera != null)
+            playerCamera.enabled = (newState == GameState.Exploration || newState == GameState.Prospecting || newState == GameState.CarryingExplosive);
+        
+        if (tileSelectionCamera != null)
+            tileSelectionCamera.enabled = (newState == GameState.TileSelection || newState == GameState.ThrowObject);
+
         if (holoCone != null)
-        {
-            holoCone.SetActive(newState == GameState.Prospecting || newState == GameState.TileSelection);
-        }
+            holoCone.SetActive(newState == GameState.Prospecting || newState == GameState.TileSelection || newState == GameState.ThrowObject);
+
+        if (carriedExplosiveVisual != null)
+            // Keep the visual active while carrying and aiming the throw
+            carriedExplosiveVisual.SetActive(newState == GameState.CarryingExplosive || newState == GameState.ThrowObject);
 
         if (newState == GameState.Exploration)
         {
             currentTargetTile = null;
         }
+
+        if (newState == GameState.ThrowObject)
+        {
+            HexTile selectedTile = ProspectingManager.Instance.CurrentlySelectedTile;
+            if (tileSelectionCamera != null && selectedTile != null)
+            {
+                tileSelectionCamera.Follow = selectedTile.transform;
+                tileSelectionCamera.LookAt = selectedTile.transform;
+            }
+        }
     }
-    
+
     private void NavigateTiles(Vector2 moveInput)
     {
         HexTile currentSelection = ProspectingManager.Instance.CurrentlySelectedTile;
@@ -196,5 +239,80 @@ public class PlayerController : MonoBehaviour
     {
         Gizmos.color = Color.yellow;
         Gizmos.DrawWireSphere(transform.position, interactionRadius);
+
+        // Draw the throw range when carrying an explosive
+        if (GameManager.Instance != null && 
+           (GameManager.Instance.CurrentState == GameState.CarryingExplosive || GameManager.Instance.CurrentState == GameState.ThrowObject))
+        {
+            Gizmos.color = Color.red;
+            Gizmos.DrawWireSphere(transform.position, throwRange);
+        }
     }
+
+    // --- NUEVO MÉTODO DE INPUT ---
+    public void OnThrowMode(InputAction.CallbackContext context)
+    {
+        if (!context.performed || GameManager.Instance.CurrentState != GameState.CarryingExplosive) return;
+
+        GameManager.Instance.EnterThrowObjectMode();
+        FindClosestTile();
+        if (currentTargetTile != null)
+        {
+            ProspectingManager.Instance.SetSelectedTile(currentTargetTile);
+        }
+        else
+        {
+            // If no tile is nearby, select the first tile of the grid as a fallback
+            ProspectingManager.Instance.SelectFirstTile();
+        }
+    }
+
+    private void ThrowExplosive(HexTile targetTile)
+    {
+        float distance = Vector3.Distance(transform.position, targetTile.transform.position);
+        if (distance > throwRange)
+        {
+            Debug.LogWarning($"Target {targetTile.name} is out of range! ({distance:F1}m > {throwRange}m)");
+            // Future: Add visual/sound feedback to the player
+            return;
+        }
+
+        Debug.Log($"Throwing explosive at {targetTile.name}.");
+        if (targetTile.hasMineral)
+        {
+            targetTile.ExtractMineral();
+        }
+        else
+        {
+            Debug.Log("Threw explosive, but no mineral was on the target tile.");
+        }
+        GameManager.Instance.EnterExplorationMode();
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (GameManager.Instance.CurrentState != GameState.Exploration) return;
+
+        if (other.CompareTag("DisarmedExplosive"))
+        {
+            Debug.Log("Player picked up a disarmed explosive.");
+            Destroy(other.gameObject);
+            GameManager.Instance.EnterCarryingExplosiveMode();
+        }
+        else if (other.CompareTag("MineralCollectible"))
+        {
+            Debug.Log("Player collected a mineral.");
+            ProspectingManager.Instance.CollectMineral();
+            Destroy(other.gameObject);
+        }
+    }
+
+    public void DetonateCarriedExplosive()
+    {
+        Debug.LogWarning("BOOM! Player detonated the carried explosive!");
+        // Here you would add damage logic to the player
+        GameManager.Instance.EnterExplorationMode();
+    }
+
+
 }

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Player/PlayerMovement.cs
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Scripts/Player/PlayerMovement.cs
@@ -8,24 +8,45 @@ public class PlayerMovement : MonoBehaviour
     [SerializeField] private float rotationSpeed = 15f;
     [SerializeField] private float gravity = -9.81f;
 
+    [Header("Explosive Carrying Settings")]
+    [SerializeField] private float carryingSpeedModifier = 0.5f;
+    [SerializeField] private float detonationThreshold = 15f; // Velocidad instantánea que causa la detonación
+
     // Referencias de componentes
     private CharacterController controller;
     private Transform mainCameraTransform;
+    private PlayerController playerController; // Referencia para llamar a la detonación
 
     // Estado del movimiento
     private Vector3 playerVelocity;
+    private Vector3 lastPosition;
 
     private void Awake()
     {
         // Obtenemos las referencias que este script necesita para funcionar
         controller = GetComponent<CharacterController>();
+        playerController = GetComponent<PlayerController>();
         mainCameraTransform = Camera.main.transform;
+        lastPosition = transform.position;
     }
 
     // El método Update se mantiene para manejar la física constante como la gravedad.
     // Solo se ejecutará si el componente está habilitado (en Modo Exploración).
     private void Update()
     {
+        // --- Lógica de Detonación por Movimiento Brusco ---
+        if (GameManager.Instance.CurrentState == GameState.CarryingExplosive)
+        {
+            Vector3 currentVelocity = (transform.position - lastPosition) / Time.deltaTime;
+            if (currentVelocity.magnitude > detonationThreshold)
+            {
+                playerController.DetonateCarriedExplosive();
+                lastPosition = transform.position; // Reset position to prevent multiple detonations
+                return; // Salir para evitar más procesamiento este frame
+            }
+        }
+        lastPosition = transform.position;
+
         // Mantenemos al personaje pegado al suelo
         if (controller.isGrounded && playerVelocity.y < 0)
         {
@@ -43,6 +64,12 @@ public class PlayerMovement : MonoBehaviour
     /// </summary>
     public void ProcessMove(Vector2 moveInput)
     {
+        float currentSpeed = moveSpeed;
+        if (GameManager.Instance.CurrentState == GameState.CarryingExplosive)
+        {
+            currentSpeed *= carryingSpeedModifier;
+        }
+
         // Creamos un vector de movimiento 3D a partir del input 2D
         Vector3 moveDirection = new Vector3(moveInput.x, 0, moveInput.y);
 
@@ -56,7 +83,7 @@ public class PlayerMovement : MonoBehaviour
             Vector3 move = moveDirection.z * cameraForward + moveDirection.x * mainCameraTransform.right;
 
             // Movemos el CharacterController
-            controller.Move(move * moveSpeed * Time.deltaTime);
+            controller.Move(move * currentSpeed * Time.deltaTime);
 
             // --- Lógica de Rotación ---
             // Hacemos que el personaje rote suavemente para mirar en la dirección en la que se mueve

--- a/Astrosweeper/Assets/_Project_Astrosweeper/Settings/PlayerControls.inputactions
+++ b/Astrosweeper/Assets/_Project_Astrosweeper/Settings/PlayerControls.inputactions
@@ -58,6 +58,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "ThrowMode",
+                    "type": "Button",
+                    "id": "8a6b3349-5bf7-4446-80bd-a6e59257c0b6",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -223,6 +232,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "UseItem",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a4c073fe-1926-44ef-b3e6-a48cdbd879ec",
+                    "path": "<Keyboard>/f",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ThrowMode",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Astrosweeper/ProjectSettings/TagManager.asset
+++ b/Astrosweeper/ProjectSettings/TagManager.asset
@@ -3,7 +3,9 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 3
-  tags: []
+  tags:
+  - MineralCollectible
+  - DisarmedExplosive
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
feat: Implement interactive explosive throwing mechanic

Replaces the previous basic explosive usage with a new, skill-based system to enhance gameplay depth and provide players with a more tactical tool for mineral extraction.

This commit introduces a complete gameplay loop for picking up, aiming, and throwing explosives at target tiles.

Key Changes:
- **State Machine Integration:** The `GameManager` now includes new states to manage the process: `CarryingExplosive` and `ThrowObject`.
- **Player Interaction Flow:**
  - Players can pick up `DisarmedExplosive` objects.
  - Pressing 'F' enters a dedicated overhead `ThrowObject` aiming mode.
  - Movement keys select a target tile, constrained by a maximum range.
  - Pressing 'E' confirms the throw.
- **Projectile System:**
  - A new `ExplosiveProjectile` prefab and script handle the visual travel of the explosive.
  - The projectile moves along a configurable parabolic arc, determined by `throwDuration` and `throwArcHeight`.
- **Configuration:**
  - The `PlayerController` now exposes key parameters in the Inspector:
    - `throwRange`: Max throw distance.
    - `explosiveProjectilePrefab`: The projectile to instantiate.
    - `throwDuration`: The speed of the projectile's travel.
    - `throwArcHeight`: The height of the throw's arc.
- **Impact Logic:** Upon arrival, the projectile triggers the `ExtractMineral` function on the target tile and is then destroyed.